### PR TITLE
closed #67 baseball-game-67 게임룸 진행바가 중간에 꺼지거나 다시 시작되는 문제 해결하기

### DIFF
--- a/src/main/resources/static/scripts/v_game_pad.js
+++ b/src/main/resources/static/scripts/v_game_pad.js
@@ -385,8 +385,8 @@ app.v_game_pad = (function () {
         title : '오류',
         ok : '확인',
         text : message
-          + '(입력 오류 : ' + app.m_player.getInfo().wrongCount + '/'
-          + app.v_game_room.getGameRoomModel().setting.limitWrongInputCount + ')'
+        + '(입력 오류 : ' + app.m_player.getInfo().wrongCount + '/'
+        + app.v_game_room.getGameRoomModel().setting.limitWrongInputCount + ')'
       });
       webix.message(message, 'error');
     }
@@ -401,7 +401,7 @@ app.v_game_pad = (function () {
     $$('number-pad').showProgress({
       type : 'top',
       delay : configMap.input_delay,
-      hide : true,
+      hide : false,
       position : 0
     });
 
@@ -412,6 +412,9 @@ app.v_game_pad = (function () {
   };
 
   _hideProgressBar = function (now) {
+    if (now === undefined || now === null) {
+      now = true;
+    }
     $$('number-pad').hideProgress(now);
   };
 


### PR DESCRIPTION
- webix 의 progress 를 사용할 때 옵션으로 hide : true 를 주게 되면 자동으로 시간이 되면 멈추게 되는데 멈추기 전에 hideProgress 를 호출하게 되더라도 progress 가 메모리에서 사라지지 않고 delay 시간 만큼 지난뒤 자체적으로 hideProgress 를 호출하게 된다
